### PR TITLE
Downgrading PHPUnit example namespace to 9

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
     cacheResult="false"
     bootstrap="bootstrap.php"
 >

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Alternatively, you can include or require ``vendor/aldavigdis/wp-tests-strapon/b
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
     cacheResult="false"
     bootstrap="vendor/aldavigdis/wp-tests-strapon/bootstrap.php"
 >


### PR DESCRIPTION
As `yoast/phpunit-polyfills`, which the WordPress test suite itself depends on for working only supports PHPUnit 9, we need to downgrade our own `phpunit.xml` as well as the example used in the readme.