### PR TITLE
Making PHPUnit a development dependency

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,8 +2,10 @@
 
 require_once 'vendor/autoload.php';
 
-require __DIR__ . '/supressors/SupressFramework.php';
-require __DIR__ . '/supressors/SupressFrameworkError.php';
+if ( 1 === version_compare( \PHPUnit\Runner\Version::id(), '10' ) ) {
+    require __DIR__ . '/supressors/SupressFramework.php';
+    require __DIR__ . '/supressors/SupressFrameworkError.php';
+}
 
 use Aldavigdis\WpTestsStrapon\Bootstrap;
 use Aldavigdis\WpTestsStrapon\FetchWP;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,6 +2,8 @@
 
 require_once 'vendor/autoload.php';
 
+# The WP test suite assumes the existence of classes that only exist in
+# version 9 and older of PHPUnit. This solves that.
 if ( 1 === version_compare( \PHPUnit\Runner\Version::id(), '10' ) ) {
     require __DIR__ . '/supressors/SupressFramework.php';
     require __DIR__ . '/supressors/SupressFrameworkError.php';

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
     "require": {
         "composer-plugin-api": "^2.6",
         "yoast/phpunit-polyfills": "^2.0",
-        "phpunit/phpunit": "^10.0",
         "simoneast/simple-ansi-colors": "^1.0"
     },
     "require-dev": {
         "composer/composer": "^2.7",
         "psy/psysh": "^0.12.0",
         "wp-coding-standards/wpcs": "^3.0",
-        "squizlabs/php_codesniffer": "^3.8"
+        "squizlabs/php_codesniffer": "^3.8",
+        "phpunit/phpunit": "^10.0"
     },
     "license": "AGPL-3.0-or-later",
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23d93f60680043a65b0c771c7476fe9b",
+    "content-hash": "30580d7df6e9e43709523d2b3b887b7c",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -2075,16 +2075,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace"
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4775f35b2d70865807c89d32c8e7385b86eb0ace",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
                 "shasum": ""
             },
             "require": {
@@ -2126,7 +2126,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.3"
             },
             "funding": [
                 {
@@ -2142,7 +2142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-07T15:38:35+00:00"
+            "time": "2024-03-19T10:26:25+00:00"
         },
         {
             "name": "composer/semver",

--- a/readme.md
+++ b/readme.md
@@ -21,23 +21,8 @@ WP-Tests-Strapon integrates with PHPUnit and acts as a bootstrap layer between y
 
 ## Installation
 
-As this in an early development version of this package that has not been uploaded to Packagist yet, you are going to need to add the Git repository manually to your `composer.json` file in order to use Alda's WP-Tests-Strapon.
-
-For the time being, you also need to set the `"minimum-stability"` attribute in your `composer.json` file to `"dev"`. (Yup, this may not be quite ready for production use, but it will change once the 0.1 release is out.)
-
-Example:
-
-```json
-{
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/aldavigdis/wp-tests-strapon.git"
-        }
-    ],
-    "minimum-stability": "dev"
-}
-```
+1. Make sure you have version 9 or 10 of PHPUnit installed as a development dependency for your project.
+2. Install the Composer package using `composer require --dev aldavigdis/wp-tests-strapon`.
 
 Finally, Open up your PHPUnit configuration file (`phpunit.xml` or `phpunit.xml.dist`) and set the `bootstrap` attribute of the root `<phpunit>` element to `vendor/aldavigdis/wp-tests-strapon/bootstrap.php`.
 


### PR DESCRIPTION
This should allow for more flexibility when it comes to different versions of PHPUnit as WP itself along with related development tools only supports version 9.